### PR TITLE
pkgmgr diff should treat obsolete/renamed packages as gone

### DIFF
--- a/bin/pkgmgr
+++ b/bin/pkgmgr
@@ -310,6 +310,8 @@ sub main {
                 my $rep = $_;
                 $_ => {
                     map { $pkgUtils->getNameVersion($_->{'pkg.fmri'}) }
+                       grep { !exists $_->{'pkg.obsolete'} &&
+                           !exists $_->{'pkg.renamed'} }
                         reverse @{listPackages($config, $opts->{$rep}->{repo},
                             $opts->{$rep}->{opts})}
                 }


### PR DESCRIPTION
Otherwise none of the packages which have been obsoleted are showing up as `removed` in r151026.